### PR TITLE
Add tests for start command

### DIFF
--- a/tests/test_start_command.py
+++ b/tests/test_start_command.py
@@ -1,0 +1,37 @@
+import sys
+import types
+import asyncio
+from unittest.mock import MagicMock, AsyncMock
+from importlib import util
+from pathlib import Path
+
+# Create fake telegram modules to satisfy imports in start.py
+telegram = types.ModuleType("telegram")
+telegram.Update = object
+telegram_ext = types.ModuleType("telegram.ext")
+class DummyContextTypes:
+    DEFAULT_TYPE = object
+telegram_ext.ContextTypes = DummyContextTypes
+sys.modules.setdefault("telegram", telegram)
+sys.modules.setdefault("telegram.ext", telegram_ext)
+
+# Load the start module directly to avoid conflicts with bot.py
+spec = util.spec_from_file_location(
+    "start_module",
+    Path(__file__).resolve().parents[1] / "bot" / "commands" / "start.py"
+)
+start_module = util.module_from_spec(spec)
+spec.loader.exec_module(start_module)
+start_command = start_module.start_command
+
+def test_start_command_replies_expected_text():
+    update = MagicMock()
+    update.message = MagicMock()
+    update.message.reply_text = AsyncMock()
+    context = MagicMock()
+
+    asyncio.run(start_command(update, context))
+
+    update.message.reply_text.assert_awaited_once_with(
+        "Привет! Я помогу тебе выработать полезные привычки. Используй /add для создания задачи."
+    )


### PR DESCRIPTION
## Summary
- add pytest-based test for the Telegram start command
- include a tests directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841abec46608325bb684675c7f9de70